### PR TITLE
Include Nyquist bin, halve it for even lengths (Morse)

### DIFF
--- a/jWavelet/morsewave.m
+++ b/jWavelet/morsewave.m
@@ -256,7 +256,10 @@ end
 X=vswap(X,inf,0);
 
 ommat=vrep(vrep(om,size(X,3),3),size(X,2),2);
-Xr=X.*rot(ommat.*(N+1)/2*fact); %ensures wavelets are centered 
+Xr=X.*(-1).^[0:N-1]'; %ensures wavelets are centered
+if ~mod(N, 2)
+  Xr(N/2+1, :)/=2; %ensures proper wavelet decay and analyticity
+endif
 %figure,plot(vrep(om,size(X,2),2).*(N+1)/2*fact)
 
 x=ifft(Xr);
@@ -267,7 +270,7 @@ function[psif]=morsewave_first_family(fact,N,K,ga,be,om,psizero,str)
 r=(2*be+1)./ga;
 c=r-1;
 L=0*om;
-index=(1:round(N/2));
+index=(1:floor(N/2)+1);
 psif=zeros(length(psizero),1,K);
 
 for k=0:K-1


### PR DESCRIPTION
Addresses #13.

Note that for odd lengths, not halving last bin (non-Nyquist) is proper and preserves analyticity, but loses fast decay. This decay seems irrelevant for CWT, but not if otherwise working directly with time-domain wavelet. This is conveniently worked around if CWT pads up to next-highest power of 2 (e.g. reflective padding), alleviating boundary effects and yielding analyticity w/ fast decay.